### PR TITLE
deps: non-default vendored-openssl feature, pin cocogitto

### DIFF
--- a/.github/workflows/call-build-upload.yml
+++ b/.github/workflows/call-build-upload.yml
@@ -41,6 +41,7 @@ jobs:
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - target: aarch64-unknown-linux-gnu

--- a/.github/workflows/call-build-upload.yml
+++ b/.github/workflows/call-build-upload.yml
@@ -12,6 +12,16 @@ on:
       tag_ref:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      package_name:
+        description: The name of the package (e.g. 'koji')
+        required: true
+        type: string
+      tag_ref:
+        description: The tag reference (e.g. 'refs/tags/v0.1.0')
+        required: true
+        type: string
 
 env:
   CARGO_INCREMENTAL: 0
@@ -64,4 +74,5 @@ jobs:
           target: ${{ matrix.target }}
           tar: all
           zip: windows
+          features: ${{ contains(matrix.target, 'windows') && 'vendored-openssl' || '' }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-release-plz.yml
+++ b/.github/workflows/push-release-plz.yml
@@ -38,5 +38,6 @@ jobs:
       package_name: ${{ matrix.release.package_name }}
       tag_ref: refs/tags/${{ matrix.release.tag }}
     strategy:
+      fail-fast: false
       matrix:
         release: ${{ fromJson(needs.release-plz.outputs.releases) }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,10 @@
 name = "koji"
 version = "2.2.0"
 edition = "2021"
-authors = ["Finley Thomalla <finley@thomalla.ch>", "Danny Tatom <its.danny@hey.com>"]
+authors = [
+  "Finley Thomalla <finley@thomalla.ch>",
+  "Danny Tatom <its.danny@hey.com>",
+]
 description = "An interactive CLI for creating conventional commits."
 documentation = "https://docs.rs/koji"
 repository = "https://github.com/cococonscious/koji"
@@ -19,15 +22,18 @@ path = "src/lib/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
-cocogitto = { version = "6.0", default-features = false }
+cocogitto = { version = "< 6.1", default-features = false }
 conventional_commit_parser = "0.9"
 dirs = "5.0"
 emojis = "0.6"
-git2 = { version = "0.18", features = ["vendored-openssl"] }
+git2 = { version = "0.18" }
 indexmap = "2.1"
 requestty = "0.5"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
+
+[features]
+vendored-openssl = ["git2/vendored-openssl"]
 
 [dev-dependencies]
 rusty-hook = "0.11"


### PR DESCRIPTION
Makes the change introduced in 70d5b2e optional and only be used in Windows builds. Pinned cocogitto because it doesn't respect semantic versioning yet.

Closes #90 