### PR TITLE
feat: git-like -C argument, integration tests

### DIFF
--- a/.github/workflows/call-build-upload.yml
+++ b/.github/workflows/call-build-upload.yml
@@ -31,6 +31,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
   RUSTUP_MAX_RETRIES: 10
+  ACT: false
 
 defaults:
   run:
@@ -71,17 +72,16 @@ jobs:
           key: ${{ matrix.target }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/setup-cross-toolchain-action@v1
+        if: startsWith(matrix.os, 'ubuntu')
         with:
           target: ${{ matrix.target }}
-        if: startsWith(matrix.os, 'ubuntu') && !contains(matrix.target, '-musl')
-      - uses: taiki-e/install-action@cross
-        if: contains(matrix.target, '-musl')
       - uses: taiki-e/upload-rust-binary-action@v1
         with:
+          dry-run: ${{ env.ACT }}
           bin: ${{ inputs.package_name }}
           ref: ${{ inputs.tag_ref }}
           target: ${{ matrix.target }}
           tar: all
           zip: windows
-          features: ${{ contains(matrix.target, 'windows') && 'vendored-openssl' || '' }}
+          features: 'vendored-openssl'
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -10,6 +10,9 @@ on:
       - main
   pull_request:
 
+env:
+  ACT: false
+
 jobs:
   test:
     name: cargo test
@@ -29,7 +32,7 @@ jobs:
       - run: cargo test --all-features
 
   coverage:
-    name: cargo tarpaulin & codecov
+    name: cargo llvm-cov & codecov
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2
@@ -41,12 +44,16 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo install cargo-tarpaulin
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@cargo-llvm-cov
       - run: git config --global user.name "tests" && git config --global user.email "tests@example.org"
-      - run: cargo tarpaulin --out Xml
+      - run: cargo llvm-cov --codecov --output-path codecov.json
       - uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: codecov.json
+          fail_ci_if_error: true
+          dry_run: ${{ env.ACT }}
 
   lints:
     name: cargo clippy & fmt
@@ -62,7 +69,6 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
+      - run: rustup component add rustfmt clippy
       - run: cargo clippy --all-targets --all-features -- -D warnings
       - run: cargo fmt --all -- --check

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -32,7 +32,7 @@ jobs:
       - run: cargo test --all-features
 
   coverage:
-    name: cargo llvm-cov & codecov
+    name: cargo tarpaulin & codecov
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -51,7 +51,6 @@ jobs:
       - uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: codecov.json
           fail_ci_if_error: true
           dry_run: ${{ env.ACT }}
 

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -25,6 +25,7 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
+      - run: git config --global user.name "tests" && git config --global user.email "tests@example.org"
       - run: cargo test --all-features
 
   coverage:
@@ -41,6 +42,7 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo install cargo-tarpaulin
+      - run: git config --global user.name "tests" && git config --global user.email "tests@example.org"
       - run: cargo tarpaulin --out Xml
       - uses: codecov/codecov-action@v4.6.0
         with:

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -45,9 +45,9 @@ jobs:
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cargo-tarpaulin
       - run: git config --global user.name "tests" && git config --global user.email "tests@example.org"
-      - run: cargo llvm-cov --codecov --output-path codecov.json
+      - run: cargo tarpaulin --out Xml --engine llvm
       - uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "doc-comment",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +131,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
 dependencies = [
  "memchr",
+ "regex-automata",
  "serde",
 ]
 
@@ -309,6 +326,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "comma"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b672471b4e9f9e95499ea597ff64941a309b2cdbffcc46f2cc5e2d971fd335"
+
+[[package]]
 name = "config"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,6 +435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +481,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
@@ -515,6 +550,15 @@ name = "fastrand"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
+
+[[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "form_urlencoded"
@@ -930,6 +974,7 @@ name = "koji"
 version = "3.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "clap_complete_command",
  "cocogitto",
@@ -939,6 +984,8 @@ dependencies = [
  "git2",
  "indexmap 2.6.0",
  "inquire",
+ "predicates",
+ "rexpect",
  "rusty-hook",
  "serde",
  "tempfile",
@@ -1081,6 +1128,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1147,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "num-traits"
@@ -1282,6 +1346,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1471,19 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rexpect"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c020234fb542618dc3e3d43724e9d93f87e1db74040a76a8c4e830220fb9b20d"
+dependencies = [
+ "comma",
+ "nix",
+ "regex",
+ "tempfile",
+ "thiserror",
+]
 
 [[package]]
 name = "rustix"
@@ -1638,6 +1745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1953,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -126,9 +126,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40723b8fb387abc38f4f4a37c09073622e41dd12327033091ef8950659e6dc0c"
+checksum = "1a68f1f47cdf0ec8ee4b941b2eee2a80cb796db73118c0dd09ac63fbe405be22"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -149,9 +149,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.1.37"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40545c26d092346d8a8dab71ee48e7685a7a9cba76e634790c215b41a4a7b4cf"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -222,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.37"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11611dca53440593f38e6b25ec629de50b14cdfa63adc0fb856115a2c6d97595"
+checksum = "d9647a559c112175f17cf724dc72d3645680a883c58481332779192b0d8e7a01"
 dependencies = [
  "clap",
 ]
@@ -276,15 +276,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
 
 [[package]]
 name = "cocogitto"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345d43a6571be5c7de58acc78b179b7cd3bf15ac8c8a82048d0ddfe94ab07311"
+checksum = "c7587c4419a57640b3e08943f82822903b61bb48dfdc7fcd1e35534575f3b4b8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -361,9 +361,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -537,12 +537,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -670,9 +670,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
@@ -899,7 +899,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -947,9 +947,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jobserver"
@@ -1000,9 +1000,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.162"
+version = "0.2.166"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
+checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
 
 [[package]]
 name = "libgit2-sys"
@@ -1068,9 +1068,9 @@ checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1177,9 +1177,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.4.0+3.4.0"
+version = "300.4.1+3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a709e02f2b4aca747929cca5ed248880847c650233cf8b8cdc48f40aaf4898a6"
+checksum = "faa4eac4138c62414b5622d1b31c5c304f34b406b013c079c2bbc652fdd6678c"
 dependencies = [
  "cc",
 ]
@@ -1237,9 +1237,9 @@ dependencies = [
 
 [[package]]
 name = "pathdiff"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5ce1153ab5b689d0c074c4e7fc613e942dfb7dd9eea5ab202d2ad91fe361"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1377,9 +1377,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1457,9 +1457,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -1539,18 +1539,18 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",
@@ -1680,9 +1680,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.87"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1897,9 +1897,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1915,9 +1915,9 @@ checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2275,9 +2275,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2287,9 +2287,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2320,18 +2320,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.12.0"
 rexpect = "0.6.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ tempfile = "3.12.0"
 rexpect = "0.6.0"
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage,coverage_nightly)'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }
 
 [profile.release]
 opt-level = "z"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/lib/lib.rs"
 [dependencies]
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
-cocogitto = { version = "6.1", default-features = false }
+cocogitto = { version = "6.2", default-features = false }
 conventional_commit_parser = "0.9"
 dirs = "5.0"
 emojis = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,13 @@ clap_complete_command = { version = "0.6.1", features = ["nushell"]}
 vendored-openssl = ["git2/vendored-openssl"]
 
 [dev-dependencies]
+assert_cmd = "2.0.16"
+predicates = "3.1.2"
 rusty-hook = "0.11"
 tempfile = "3.12.0"
+
+[target.'cfg(not(windows))'.dev-dependencies]
+rexpect = "0.6.0"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tarpaulin_include)'] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -158,7 +158,7 @@ fn main() -> Result<()> {
         path: config,
         sign,
         _user_config_path: None,
-        _current_dir: Some(current_dir),
+        _current_dir: Some(current_dir.clone()),
     }))?;
 
     // Get answers from interactive prompt
@@ -189,7 +189,7 @@ fn main() -> Result<()> {
             update_files: false,
         };
 
-        commit(options)?;
+        commit(current_dir, options)?;
     }
 
     Ok(())

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -103,7 +103,6 @@ enum SubCmds {
     Completions { shell: clap_complete_command::Shell },
 }
 
-#[cfg(not(tarpaulin_include))]
 fn main() -> Result<()> {
     // Get CLI args
     let Args {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,4 +1,5 @@
 use std::fs::read_to_string;
+use std::path::PathBuf;
 
 use anyhow::{Context, Result};
 use clap::{CommandFactory, Parser, Subcommand};
@@ -87,6 +88,13 @@ struct Args {
 
     #[arg(short, long, help = "Stage all tracked modified or deleted files")]
     all: bool,
+
+    #[arg(
+        short = 'C',
+        value_name = "PATH",
+        help = "Run as if koji was started in <path>"
+    )]
+    current_workdir: Option<PathBuf>,
 }
 
 #[derive(Debug, Subcommand)]
@@ -108,6 +116,7 @@ fn main() -> Result<()> {
         issues,
         sign,
         all,
+        current_workdir,
     } = Args::parse();
 
     if command.is_some() {
@@ -119,9 +128,13 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
+    let current_dir = match current_workdir {
+        Some(dir) => dir,
+        None => std::env::current_dir()?,
+    };
+
     // Find repo
-    let repo =
-        Repository::discover(std::env::current_dir()?).context("could not find git repository")?;
+    let repo = Repository::discover(&current_dir).context("could not find git repository")?;
 
     // Get existing commit message (passed in via `-m`)
     let commit_editmsg = repo.path().join("COMMIT_EDITMSG");
@@ -145,7 +158,7 @@ fn main() -> Result<()> {
         path: config,
         sign,
         _user_config_path: None,
-        _current_dir: None,
+        _current_dir: Some(current_dir),
     }))?;
 
     // Get answers from interactive prompt

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -103,6 +103,7 @@ enum SubCmds {
     Completions { shell: clap_complete_command::Shell },
 }
 
+#[cfg(not(tarpaulin_include))]
 fn main() -> Result<()> {
     // Get CLI args
     let Args {

--- a/src/lib/commit.rs
+++ b/src/lib/commit.rs
@@ -6,7 +6,6 @@ use cocogitto::CocoGitto;
 use git2::Repository;
 
 /// Output a commit message to `.git/COMMIT_EDITMSG`
-#[cfg(not(tarpaulin_include))]
 pub fn write_commit_msg(
     repo: &Repository,
     commit_type: String,
@@ -33,7 +32,6 @@ pub fn write_commit_msg(
 }
 
 /// Create a commit
-#[cfg(not(tarpaulin_include))]
 pub fn commit(current_dir: PathBuf, options: CommitOptions) -> Result<()> {
     let cocogitto = CocoGitto::get_at(current_dir)?;
 

--- a/src/lib/commit.rs
+++ b/src/lib/commit.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Write};
+use std::{fs::File, io::Write, path::PathBuf};
 
 use anyhow::Result;
 use cocogitto::command::commit::CommitOptions;
@@ -34,8 +34,8 @@ pub fn write_commit_msg(
 
 /// Create a commit
 #[cfg(not(tarpaulin_include))]
-pub fn commit(options: CommitOptions) -> Result<()> {
-    let cocogitto = CocoGitto::get()?;
+pub fn commit(current_dir: PathBuf, options: CommitOptions) -> Result<()> {
+    let cocogitto = CocoGitto::get_at(current_dir)?;
 
     cocogitto.conventional_commit(options)?;
 

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub emoji: bool,
     pub issues: bool,
     pub sign: bool,
+    pub workdir: PathBuf,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -58,6 +59,8 @@ impl Config {
             _current_dir,
         } = args.unwrap_or_default();
 
+        let workdir = _current_dir.unwrap_or(current_dir()?);
+
         // Get the default config
         let default_str = include_str!("../../meta/config/default.toml");
         let default_config: ConfigTOML =
@@ -75,7 +78,7 @@ impl Config {
         };
 
         // Try to get config from working directory
-        let working_dir_path = _current_dir.unwrap_or(current_dir()?).join(".koji.toml");
+        let working_dir_path = workdir.join(".koji.toml");
         if Path::new(&working_dir_path).exists() {
             let contents = read_to_string(working_dir_path).context("could not read config")?;
             parsed = Some(toml::from_str(&contents).context("could not parse config")?);
@@ -115,6 +118,7 @@ impl Config {
             emoji: emoji.unwrap_or(config.emoji.unwrap_or(false)),
             issues: issues.unwrap_or(config.issues.unwrap_or(true)),
             sign: sign.unwrap_or(config.sign.unwrap_or(false)),
+            workdir,
         })
     }
 }

--- a/src/lib/config.rs
+++ b/src/lib/config.rs
@@ -5,6 +5,7 @@ use serde::Deserialize;
 use std::path::PathBuf;
 use std::{env::current_dir, fs::read_to_string, path::Path};
 
+#[derive(Debug, Clone)]
 pub struct Config {
     pub autocomplete: bool,
     pub breaking_changes: bool,

--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -94,13 +94,8 @@ impl ScopeAutocompleter {
         let repo =
             Repository::discover(&self.config.workdir).context("could not find git repository")?;
 
-        match repo.is_empty() {
-            Ok(empty) => {
-                if empty {
-                    return Ok(Vec::new());
-                }
-            }
-            Err(_) => return Ok(Vec::new()),
+        if repo.is_empty()? {
+            return Ok(Vec::new());
         }
 
         let mut walk = repo.revwalk()?;
@@ -130,7 +125,7 @@ impl ScopeAutocompleter {
 
 impl Autocomplete for ScopeAutocompleter {
     fn get_suggestions(&mut self, input: &str) -> Result<Vec<String>, CustomUserError> {
-        let existing_scopes = self.get_existing_scopes()?;
+        let existing_scopes = self.get_existing_scopes().unwrap_or_default();
 
         Ok(existing_scopes
             .iter()

--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -94,10 +94,6 @@ impl ScopeAutocompleter {
         let repo =
             Repository::discover(&self.config.workdir).context("could not find git repository")?;
 
-        if repo.is_empty()? {
-            return Ok(Vec::new());
-        }
-
         let mut walk = repo.revwalk()?;
 
         walk.push_head()?;

--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -94,8 +94,13 @@ impl ScopeAutocompleter {
         let repo =
             Repository::discover(&self.config.workdir).context("could not find git repository")?;
 
-        if repo.is_empty()? {
-            return Ok(Vec::new());
+        match repo.is_empty() {
+            Ok(empty) => {
+                if empty {
+                    return Ok(Vec::new());
+                }
+            }
+            Err(_) => return Ok(Vec::new()),
         }
 
         let mut walk = repo.revwalk()?;

--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -10,12 +10,10 @@ use inquire::{
     Confirm, CustomUserError, Select, Text,
 };
 
-#[cfg(not(tarpaulin_include))]
 fn get_skip_hint() -> &'static str {
     "<esc> or <return> to skip"
 }
 
-#[cfg(not(tarpaulin_include))]
 fn get_render_config() -> RenderConfig<'static> {
     RenderConfig {
         prompt: StyleSheet::new().with_attr(Attributes::BOLD),
@@ -71,7 +69,6 @@ fn validate_issue_reference(input: &str) -> Result<Validation, CustomUserError> 
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_type(config: &Config) -> Result<String> {
     let type_values = config
         .commit_types
@@ -92,7 +89,6 @@ struct ScopeAutocompleter {
     config: Config,
 }
 
-#[cfg(not(tarpaulin_include))]
 impl ScopeAutocompleter {
     fn get_existing_scopes(&self) -> Result<Vec<String>> {
         let repo =
@@ -127,7 +123,6 @@ impl ScopeAutocompleter {
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 impl Autocomplete for ScopeAutocompleter {
     fn get_suggestions(&mut self, input: &str) -> Result<Vec<String>, CustomUserError> {
         let existing_scopes = self.get_existing_scopes()?;
@@ -148,7 +143,6 @@ impl Autocomplete for ScopeAutocompleter {
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_scope(config: &Config) -> Result<Option<String>> {
     let mut scope_autocompleter = ScopeAutocompleter {
         config: config.clone(),
@@ -185,7 +179,6 @@ fn prompt_scope(config: &Config) -> Result<Option<String>> {
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_summary(msg: String) -> Result<String> {
     let previous_summary = match parse_summary(&msg) {
         Ok(parsed) => parsed.summary,
@@ -201,7 +194,6 @@ fn prompt_summary(msg: String) -> Result<String> {
     Ok(summary)
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_body() -> Result<Option<String>> {
     let help_message = format!("{}, {}", "Use '\\n' for newlines", get_skip_hint());
 
@@ -220,7 +212,6 @@ fn prompt_body() -> Result<Option<String>> {
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_breaking() -> Result<bool> {
     let answer = Confirm::new("Are there any breaking changes?")
         .with_render_config(get_render_config())
@@ -230,7 +221,6 @@ fn prompt_breaking() -> Result<bool> {
     Ok(answer)
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_breaking_text() -> Result<Option<String>> {
     let help_message = format!("{}, {}", "Use '\\n' for newlines", get_skip_hint());
 
@@ -249,7 +239,6 @@ fn prompt_breaking_text() -> Result<Option<String>> {
     }
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_issues() -> Result<bool> {
     let answer = Confirm::new("Does this change affect any open issues?")
         .with_render_config(get_render_config())
@@ -259,7 +248,6 @@ fn prompt_issues() -> Result<bool> {
     Ok(answer)
 }
 
-#[cfg(not(tarpaulin_include))]
 fn prompt_issue_text() -> Result<String> {
     let summary = Text::new("Add the issue reference:")
         .with_render_config(get_render_config())
@@ -282,7 +270,6 @@ pub struct Answers {
 }
 
 /// Create the interactive prompt
-#[cfg(not(tarpaulin_include))]
 pub fn create_prompt(last_message: String, config: &Config) -> Result<Answers> {
     let commit_type = prompt_type(config)?;
     let scope = prompt_scope(config)?;

--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -134,6 +134,7 @@ impl Autocomplete for ScopeAutocompleter {
             .collect())
     }
 
+    #[cfg(not(tarpaulin_include))]
     fn get_completion(
         &mut self,
         _input: &str,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -105,21 +105,28 @@ fn test_everything_correct() -> Result<(), Box<dyn Error>> {
 
     process.expect_commit_type()?;
     process.send_line("feat")?;
+    process.flush()?;
     process.expect_scope()?;
     process.send_line("config")?;
+    process.flush()?;
     process.expect_summary()?;
     process.send_line("refactor config pairs")?;
+    process.flush()?;
     process.expect_body()?;
     process
         .send_line("Removed and added a config pair each\\nNecessary for future compatibility.")?;
     process.expect_breaking()?;
     process.send_line("Y")?;
+    process.flush()?;
     process.expect_breaking_details()?;
     process.send_line("Something can't be configured anymore")?;
+    process.flush()?;
     process.expect_issues()?;
     process.send_line("Y")?;
+    process.flush()?;
     process.expect_issues_details()?;
     process.send_line("closes #1")?;
+    process.flush()?;
     let eof_output = process.exp_eof();
 
     let exitcode = process.process.wait()?;
@@ -165,16 +172,22 @@ fn test_hook_correct() -> Result<(), Box<dyn Error>> {
 
     process.expect_commit_type()?;
     process.send_line("fix")?;
+    process.flush()?;
     process.expect_scope()?;
     process.send_line("")?;
+    process.flush()?;
     process.expect_summary()?;
     process.send_line("some weird error")?;
+    process.flush()?;
     process.expect_body()?;
     process.send_line("")?;
+    process.flush()?;
     process.expect_breaking()?;
     process.send_line("N")?;
+    process.flush()?;
     process.expect_issues()?;
     process.send_line("N")?;
+    process.flush()?;
     let eof_output = process.exp_eof();
 
     let exitcode = process.process.wait()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,51 @@
+use git2::Repository;
+use rexpect::session::spawn_command;
+use std::{error::Error, fs, path::PathBuf, process::Command};
+use tempfile::TempDir;
+
+fn setup_test_dir() -> Result<(PathBuf, TempDir, Repository), Box<dyn Error>> {
+    let bin_path = assert_cmd::cargo::cargo_bin("koji");
+    let temp_dir = tempfile::tempdir()?;
+    let repo = Repository::init(&temp_dir)?;
+
+    Ok((bin_path, temp_dir, repo))
+}
+
+#[ignore]
+#[test]
+fn test_type_scope_summary_body_breaking_issue_add_files_correct() -> Result<(), Box<dyn Error>> {
+    let (bin_path, temp_dir, _) = setup_test_dir()?;
+
+    fs::write(temp_dir.path().join("config.json"), "abc")?;
+
+    let mut cmd = Command::new(bin_path);
+    cmd.env("NO_COLOR", "1").arg("-C").arg(temp_dir.path());
+
+    cmd.arg("-a");
+
+    let mut process = spawn_command(cmd, Some(10000))?;
+
+    process.exp_string("are you committing?")?;
+    process.send_line("feat")?;
+    process.exp_string("scope of this change?")?;
+    process.send_line("config")?;
+    process.exp_string("description of the change")?;
+    process.send_line("refactor config pairs")?;
+    process.exp_string("longer description of the change")?;
+    process
+        .send_line("Removed and added a config pair each\\nNecessary for future compatibility.")?;
+    process.exp_string("breaking changes?")?;
+    process.send_line("Y")?;
+    process.exp_string("in detail:")?;
+    process.send_line("Something can't be configured anymore")?;
+    process.exp_string("any open issues?")?;
+    process.send_line("Y")?;
+    process.exp_string("issue reference:")?;
+    process.send_line("closes #1")?;
+    println!("{:?}", process.exp_eof());
+
+    // TODO check if commit was created
+
+    temp_dir.close()?;
+    Ok(())
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -199,3 +199,30 @@ fn test_non_repository_error() -> Result<(), Box<dyn Error>> {
     temp_dir.close()?;
     Ok(())
 }
+
+#[test]
+fn test_completion_scripts_success() -> Result<(), Box<dyn Error>> {
+    fn run_for(shell: &'static str, containing: &'static str) -> Result<(), Box<dyn Error>> {
+        let bin_path = assert_cmd::cargo::cargo_bin("koji");
+
+        let mut cmd = Command::new(bin_path);
+        cmd.arg("completions").arg(shell);
+
+        let cmd_out = cmd.output()?;
+        let stdout = String::from_utf8(cmd_out.stdout)?;
+
+        assert!(cmd_out.status.success());
+        assert!(stdout.contains(containing));
+
+        Ok(())
+    }
+
+    run_for("nushell", "def \"nu-complete koji")?;
+    run_for("fish", "complete -c koji -n \"__fish_koji_needs_command")?;
+    run_for("bash", "complete -F _koji -o bashdefault -o default koji")?;
+    run_for(
+        "powershell",
+        "Register-ArgumentCompleter -Native -CommandName 'koji'",
+    )?;
+    run_for("zsh", "#compdef koji")
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use git2::{Commit, Repository, RepositoryInitOptions};
+use rexpect::session::PtySession;
 #[cfg(not(target_os = "windows"))]
 use rexpect::{process::wait, session::spawn_command};
 use std::{error::Error, fs, path::PathBuf, process::Command};
@@ -22,9 +23,54 @@ fn get_first_commit(repo: &Repository) -> Result<Commit, git2::Error> {
     repo.find_commit(oid)
 }
 
+trait ExpectPromps {
+    fn expect_commit_type(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_scope(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_summary(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_body(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_breaking(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_breaking_details(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_issues(&mut self) -> Result<String, rexpect::error::Error>;
+    fn expect_issues_details(&mut self) -> Result<String, rexpect::error::Error>;
+}
+
+impl ExpectPromps for PtySession {
+    fn expect_commit_type(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("are you committing?")
+    }
+
+    fn expect_scope(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("scope of this change?")
+    }
+
+    fn expect_summary(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("description of the change")
+    }
+
+    fn expect_body(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("longer description of the change")
+    }
+
+    fn expect_breaking(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("breaking changes?")
+    }
+
+    fn expect_breaking_details(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("in detail:")
+    }
+
+    fn expect_issues(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("any open issues?")
+    }
+
+    fn expect_issues_details(&mut self) -> Result<String, rexpect::error::Error> {
+        self.exp_string("issue reference:")
+    }
+}
+
 #[test]
 #[cfg(not(target_os = "windows"))]
-fn test_type_scope_summary_body_breaking_issue_add_files_correct() -> Result<(), Box<dyn Error>> {
+fn test_everything_correct() -> Result<(), Box<dyn Error>> {
     let (bin_path, temp_dir, repo) = setup_test_dir()?;
 
     fs::write(temp_dir.path().join("config.json"), "abc")?;
@@ -33,26 +79,27 @@ fn test_type_scope_summary_body_breaking_issue_add_files_correct() -> Result<(),
     cmd.env("NO_COLOR", "1")
         .arg("-C")
         .arg(temp_dir.path())
-        .arg("-a");
+        .arg("-a")
+        .arg("--autocomplete=true");
 
     let mut process = spawn_command(cmd, Some(5000))?;
 
-    process.exp_string("are you committing?")?;
+    process.expect_commit_type()?;
     process.send_line("feat")?;
-    process.exp_string("scope of this change?")?;
+    process.expect_scope()?;
     process.send_line("config")?;
     process.exp_string("description of the change")?;
     process.send_line("refactor config pairs")?;
-    process.exp_string("longer description of the change")?;
+    process.expect_body()?;
     process
         .send_line("Removed and added a config pair each\\nNecessary for future compatibility.")?;
-    process.exp_string("breaking changes?")?;
+    process.expect_breaking()?;
     process.send_line("Y")?;
-    process.exp_string("in detail:")?;
+    process.expect_breaking_details()?;
     process.send_line("Something can't be configured anymore")?;
-    process.exp_string("any open issues?")?;
+    process.expect_issues()?;
     process.send_line("Y")?;
-    process.exp_string("issue reference:")?;
+    process.expect_issues_details()?;
     process.send_line("closes #1")?;
     let eof_output = process.exp_eof();
 
@@ -71,6 +118,55 @@ fn test_type_scope_summary_body_breaking_issue_add_files_correct() -> Result<(),
     assert_eq!(
         commit.body(),
         Some("Removed and added a config pair each\nNecessary for future compatibility.\n\ncloses #1\nBREAKING CHANGE: Something can't be configured anymore")
+    );
+
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_hook_correct() -> Result<(), Box<dyn Error>> {
+    let (bin_path, temp_dir, _) = setup_test_dir()?;
+
+    fs::write(temp_dir.path().join("config.json"), "abc")?;
+    fs::remove_file(temp_dir.path().join(".git").join("COMMIT_EDITMSG")).unwrap_or(());
+
+    let mut cmd = Command::new(bin_path);
+    cmd.env("NO_COLOR", "1")
+        .arg("-C")
+        .arg(temp_dir.path())
+        .arg("-a")
+        .arg("--autocomplete=true");
+
+    let mut process = spawn_command(cmd, Some(5000))?;
+
+    process.expect_commit_type()?;
+    process.send_line("fix")?;
+    process.expect_scope()?;
+    process.send_line("")?;
+    process.expect_summary()?;
+    process.send_line("some weird error")?;
+    process.expect_body()?;
+    process.send_line("")?;
+    process.expect_breaking()?;
+    process.send_line("N")?;
+    process.expect_issues()?;
+    process.send_line("N")?;
+    let eof_output = process.exp_eof();
+
+    let exitcode = process.process.wait()?;
+    let success = matches!(exitcode, wait::WaitStatus::Exited(_, 0));
+
+    if !success {
+        panic!("Command exited non-zero, end of output: {:?}", eof_output);
+    }
+
+    let editmsg = temp_dir.path().join(".git").join("COMMIT_EDITMSG");
+    assert!(editmsg.exists());
+    assert_eq!(
+        fs::read(editmsg)?,
+        "fix: some weird error".as_bytes().to_vec()
     );
 
     temp_dir.close()?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -145,6 +145,7 @@ fn test_hook_correct() -> Result<(), Box<dyn Error>> {
     cmd.env("NO_COLOR", "1")
         .arg("-C")
         .arg(temp_dir.path())
+        .arg("--hook")
         .arg("--autocomplete=false");
 
     let mut process = spawn_command(cmd, Some(5000))?;
@@ -176,6 +177,24 @@ fn test_hook_correct() -> Result<(), Box<dyn Error>> {
         fs::read(editmsg)?,
         "fix: some weird error".as_bytes().to_vec()
     );
+
+    temp_dir.close()?;
+    Ok(())
+}
+
+#[test]
+fn test_non_repository_error() -> Result<(), Box<dyn Error>> {
+    let bin_path = assert_cmd::cargo::cargo_bin("koji");
+    let temp_dir = tempfile::tempdir()?;
+
+    let mut cmd = Command::new(bin_path);
+    cmd.arg("-C").arg(temp_dir.path());
+
+    let cmd_out = cmd.output()?;
+    let stderr_out = String::from_utf8(cmd_out.stderr)?;
+
+    assert!(!cmd_out.status.success());
+    assert!(stderr_out.contains("could not find git repository"));
 
     temp_dir.close()?;
     Ok(())

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,5 @@
 use git2::Repository;
+#[cfg(not(target_os = "windows"))]
 use rexpect::session::spawn_command;
 use std::{error::Error, fs, path::PathBuf, process::Command};
 use tempfile::TempDir;
@@ -13,6 +14,7 @@ fn setup_test_dir() -> Result<(PathBuf, TempDir, Repository), Box<dyn Error>> {
 
 #[ignore]
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn test_type_scope_summary_body_breaking_issue_add_files_correct() -> Result<(), Box<dyn Error>> {
     let (bin_path, temp_dir, _) = setup_test_dir()?;
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,4 +1,4 @@
-use git2::{Commit, Repository, RepositoryInitOptions, IndexAddOption};
+use git2::{Commit, IndexAddOption, Repository, RepositoryInitOptions};
 #[cfg(not(target_os = "windows"))]
 use rexpect::{
     process::wait,
@@ -77,10 +77,9 @@ fn test_everything_correct() -> Result<(), Box<dyn Error>> {
 
     fs::write(temp_dir.path().join("config.json"), "abc")?;
     // TODO properly test "-a"
-    // println!("{:?}", repo.status_file(Path::new("config.json"))?);
     repo.index()?
         .add_all(["*"].iter(), IndexAddOption::default(), None)?;
-    // println!("{:?}", repo.status_file(Path::new("config.json"))?);
+    repo.index()?.write()?;
 
     let mut cmd = Command::new(bin_path);
     cmd.env("NO_COLOR", "1")
@@ -139,6 +138,7 @@ fn test_hook_correct() -> Result<(), Box<dyn Error>> {
     fs::write(temp_dir.path().join("config.json"), "abc")?;
     repo.index()?
         .add_all(["*"].iter(), IndexAddOption::default(), None)?;
+    repo.index()?.write()?;
     fs::remove_file(temp_dir.path().join(".git").join("COMMIT_EDITMSG")).unwrap_or(());
 
     let mut cmd = Command::new(bin_path);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,7 +1,9 @@
 use git2::{Commit, Repository, RepositoryInitOptions};
-use rexpect::session::PtySession;
 #[cfg(not(target_os = "windows"))]
-use rexpect::{process::wait, session::spawn_command};
+use rexpect::{
+    process::wait,
+    session::{spawn_command, PtySession},
+};
 use std::{error::Error, fs, path::PathBuf, process::Command};
 use tempfile::TempDir;
 
@@ -88,7 +90,7 @@ fn test_everything_correct() -> Result<(), Box<dyn Error>> {
     process.send_line("feat")?;
     process.expect_scope()?;
     process.send_line("config")?;
-    process.exp_string("description of the change")?;
+    process.expect_summary()?;
     process.send_line("refactor config pairs")?;
     process.expect_body()?;
     process


### PR DESCRIPTION
Added an argument almost equivalent to Git's "-C", mainly for the purpose of making integration tests isolated. This feature depends on cocogitto/cocogitto#428, and therefore v6.2.0, as the commit will otherwise still be made in the current working directory.
This commit reduces code test coverage as many skips were removed.