### PR TITLE
fix(autocomplete): check for empty repo before revwalk

### DIFF
--- a/src/lib/questions.rs
+++ b/src/lib/questions.rs
@@ -118,6 +118,11 @@ pub fn prompt_scope(config: &Config) -> Result<Option<String>> {
     fn scope_autocompleter(val: &str) -> Result<Vec<String>, CustomUserError> {
         let repo = Repository::discover(std::env::current_dir()?)
             .context("could not find git repository")?;
+
+        if repo.is_empty()? {
+            return Ok(vec![]);
+        }
+
         let existing_scopes = get_existing_scopes(&repo)?;
 
         Ok(existing_scopes


### PR DESCRIPTION
`push_head` on Revwalk fails when the repository had just been initialized as the commit reference doesn't exist yet. A simple check for if the repository is empty fixes this.

Refs: #104