### PR TITLE
feat: add shell completions subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.5.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11611dca53440593f38e6b25ec629de50b14cdfa63adc0fb856115a2c6d97595"
+dependencies = [
+ "clap",
+]
+
+[[package]]
+name = "clap_complete_command"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "clap_complete_nushell",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "315902e790cc6e5ddd20cbd313c1d0d49db77f191e149f96397230fb82a17677"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,6 +931,7 @@ version = "2.2.0"
 dependencies = [
  "anyhow",
  "clap",
+ "clap_complete_command",
  "cocogitto",
  "conventional_commit_parser",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ indexmap = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 inquire = "0.7.5"
+clap_complete_command = { version = "0.6.1", features = ["nushell"]}
 
 [features]
 vendored-openssl = ["git2/vendored-openssl"]

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ koji
 
 See `koji --help` for more options.
 
+Use `koji completions <SHELL>` to generate completion scripts for your shell.
+
 ## Using as a git hook
 
 An alternative way to use koji is as a [git hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks),


### PR DESCRIPTION
Adds a subcommand "completions" which can generate shell completions for a few supported shells, namely bash, zsh and Nushell. 
You can use it like this: `koji completions <SHELL> > <CUSTOM_COMPLETIONS_DIR>/_koji`.
I consider this feature necessary for eventually publishing koji to other package registries, such as the AUR.