### PR TITLE
ci: split test and coverage, deps

### DIFF
--- a/.github/workflows/call-build-upload.yml
+++ b/.github/workflows/call-build-upload.yml
@@ -58,10 +58,10 @@ jobs:
             os: windows-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@v4.2.2
         with:
           ref: ${{ inputs.tag_ref }}
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.1.2
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   test:
-    name: cargo test, tarpaulin & codecov
+    name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/cache@v4.0.2
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/cache@v4.1.2
         with:
           path: |
             ~/.cargo/bin/
@@ -26,9 +26,23 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: dtolnay/rust-toolchain@stable
       - run: cargo test --all-features
+
+  coverage:
+    name: cargo tarpaulin & codecov
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/cache@v4.1.2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo install cargo-tarpaulin
       - run: cargo tarpaulin --out Xml
-      - uses: codecov/codecov-action@v4
+      - uses: codecov/codecov-action@v4.6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
@@ -36,8 +50,8 @@ jobs:
     name: cargo clippy & fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4.1.7
-      - uses: actions/cache@v4.0.2
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/cache@v4.1.2
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -42,7 +42,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo install cargo-tarpaulin
       - run: cargo tarpaulin --out Xml
-      - uses: codecov/codecov-action@v4.6
+      - uses: codecov/codecov-action@v4.6.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/push-release-plz.yml
+++ b/.github/workflows/push-release-plz.yml
@@ -17,10 +17,10 @@ jobs:
       releases: ${{ steps.release-plz.outputs.releases }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.1.7
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
-      - uses: actions/cache@v4.0.2
+      - uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
Splits the test and coverage steps into seperate jobs to parallelize them for faster workflow executions. Also upgraded the versions of all used actions.