### PR TITLE
fix(args): mutually exclusive hook and all

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -61,7 +61,8 @@ struct Args {
 
     #[arg(
         long,
-        help = "Run as a git hook, writing the commit message to COMMIT_EDITMSG instead of committing"
+        help = "Run as a git hook, writing the commit message to COMMIT_EDITMSG instead of committing",
+        conflicts_with = "all"
     )]
     hook: bool,
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -336,6 +336,23 @@ fn test_empty_repository_error() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+fn test_all_hook_exclusive_error() -> Result<(), Box<dyn Error>> {
+    let bin_path = assert_cmd::cargo::cargo_bin("koji");
+
+    let mut cmd = Command::new(bin_path);
+    cmd.arg("--hook");
+    cmd.arg("--all");
+
+    let cmd_out = cmd.output()?;
+    let stderr_out = String::from_utf8(cmd_out.stderr)?;
+
+    assert!(!cmd_out.status.success());
+    assert!(stderr_out.contains("the argument '--hook' cannot be used with '--all'"));
+
+    Ok(())
+}
+
+#[test]
 fn test_completion_scripts_success() -> Result<(), Box<dyn Error>> {
     fn run_for(shell: &'static str, containing: &'static str) -> Result<(), Box<dyn Error>> {
         let bin_path = assert_cmd::cargo::cargo_bin("koji");


### PR DESCRIPTION
As the "all" argument doesn't do anything in hook mode, we might as well just make them mutually exclusive for more clarity.