### PR TITLE
feat(args): adding 'stdout' flag

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -69,7 +69,8 @@ struct Args {
     #[arg(
         long,
         help = "Outputs the commit message to stdout instead of committing",
-        conflicts_with = "all"
+        conflicts_with = "all",
+        conflicts_with = "hook"
     )]
     stdout: bool,
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -7,7 +7,7 @@ use cocogitto::command::commit::CommitOptions;
 use conventional_commit_parser::parse;
 use git2::Repository;
 use koji::answers::{get_extracted_answers, ExtractedAnswers};
-use koji::commit::{commit, write_commit_msg};
+use koji::commit::{commit, generate_commit_msg, write_commit_msg};
 use koji::config::{Config, ConfigArgs};
 use koji::questions::create_prompt;
 
@@ -68,6 +68,13 @@ struct Args {
 
     #[arg(
         long,
+        help = "Outputs the commit message to stdout instead of committing",
+        conflicts_with = "all"
+    )]
+    stdout: bool,
+
+    #[arg(
+        long,
         default_missing_value = "true",
         num_args = 0..=1,
         value_name = "ENABLE",
@@ -114,6 +121,7 @@ fn main() -> Result<()> {
         config,
         emoji,
         hook,
+        stdout,
         issues,
         sign,
         all,
@@ -177,6 +185,11 @@ fn main() -> Result<()> {
     // Do the thing!
     if hook {
         write_commit_msg(&repo, commit_type, scope, summary, body, is_breaking_change)?;
+    } else if stdout {
+        println!(
+            "{}",
+            generate_commit_msg(commit_type, scope, summary, body, is_breaking_change)?
+        );
     } else {
         let options = CommitOptions {
             commit_type: commit_type.as_str(),

--- a/src/lib/commit.rs
+++ b/src/lib/commit.rs
@@ -5,6 +5,26 @@ use cocogitto::command::commit::CommitOptions;
 use cocogitto::CocoGitto;
 use git2::Repository;
 
+/// Generates the commit message
+pub fn generate_commit_msg(
+    commit_type: String,
+    scope: Option<String>,
+    summary: String,
+    body: Option<String>,
+    is_breaking_change: bool,
+) -> Result<String> {
+    let message = CocoGitto::get_conventional_message(
+        &commit_type,
+        scope,
+        summary,
+        body,
+        None,
+        is_breaking_change,
+    )?;
+
+    Ok(message)
+}
+
 /// Output a commit message to `.git/COMMIT_EDITMSG`
 pub fn write_commit_msg(
     repo: &Repository,
@@ -14,14 +34,7 @@ pub fn write_commit_msg(
     body: Option<String>,
     is_breaking_change: bool,
 ) -> Result<()> {
-    let message = CocoGitto::get_conventional_message(
-        &commit_type,
-        scope,
-        summary,
-        body,
-        None,
-        is_breaking_change,
-    )?;
+    let message = generate_commit_msg(commit_type, scope, summary, body, is_breaking_change)?;
 
     let commit_editmsg = repo.path().join("COMMIT_EDITMSG");
     let mut file = File::create(commit_editmsg)?;


### PR DESCRIPTION
Added a '--stdout' flag to output the message to stdout instead of continuing on with the git workflow. Allows koji to be used with non-git workflows.