### PR TITLE
test: fix rexpect windows failures, more in ci

### DIFF
--- a/.github/workflows/push-pr-lint-test.yml
+++ b/.github/workflows/push-pr-lint-test.yml
@@ -15,8 +15,24 @@ env:
 
 jobs:
   test:
-    name: cargo test
-    runs-on: ubuntu-latest
+    name: cargo test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          # Linux
+          - ubuntu-latest
+          # macOS ARM64 - Tahoe (macOS 26 beta)
+          - macos-26
+          # macOS ARM64 - Sequoia (macOS 15)
+          - macos-15
+          # macOS ARM64 - Sonoma (macOS 14)
+          - macos-14
+          # macOS Intel - Sonoma (macOS 15 Intel)
+          - macos-15-intel
+          # Windows Server
+          - windows-latest
     steps:
       - uses: actions/checkout@v6.0.1
       - uses: actions/cache@v5.0.1
@@ -26,7 +42,9 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ matrix.os }}-cargo-
       - uses: dtolnay/rust-toolchain@stable
       - run: git config --global user.name "tests" && git config --global user.email "tests@example.org"
       - run: cargo test --all-features

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,6 +44,7 @@ fn do_initial_commit(repo: &Repository, message: &'static str) -> Result<Oid, gi
     repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &[])
 }
 
+#[cfg(not(target_os = "windows"))]
 trait ExpectPromps {
     fn expect_commit_type(&mut self) -> Result<String, rexpect::error::Error>;
     fn expect_scope(&mut self) -> Result<String, rexpect::error::Error>;
@@ -55,6 +56,7 @@ trait ExpectPromps {
     fn expect_issues_details(&mut self) -> Result<String, rexpect::error::Error>;
 }
 
+#[cfg(not(target_os = "windows"))]
 impl ExpectPromps for PtySession {
     fn expect_commit_type(&mut self) -> Result<String, rexpect::error::Error> {
         self.exp_string("are you committing?")
@@ -364,6 +366,7 @@ fn test_non_repository_error() -> Result<(), Box<dyn Error>> {
 }
 
 #[test]
+#[cfg(not(target_os = "windows"))]
 fn test_empty_repository_error() -> Result<(), Box<dyn Error>> {
     let (bin_path, temp_dir, _) = setup_test_dir()?;
 


### PR DESCRIPTION
Multiple macOS versions as a requirement to eventually have koji in homebrew-core