### PR TITLE
fix(jj): load user config so committer signature is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -971,7 +971,7 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -2377,10 +2377,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2418,7 +2420,9 @@ dependencies = [
  "predicates",
  "rexpect",
  "serde",
+ "serial_test",
  "tempfile",
+ "whoami",
  "xdg",
 ]
 
@@ -2445,9 +2449,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -2471,13 +2475,14 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
- "redox_syscall",
+ "plain",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -2625,7 +2630,7 @@ checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -2670,6 +2675,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -2736,7 +2759,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -2872,6 +2895,12 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "pollster"
@@ -3098,6 +3127,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -3341,6 +3379,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "699f4197115b8a7e7ff19c9a315a4bd6fffec26cc4626ef45ecaea389e081c6d"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e153fc76e1c6a068703d6d29c508a0b15c061c4b7e43da59cc097bc342673c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3522,7 +3585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -3890,6 +3953,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3908,10 +3980,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen"
-version = "0.2.106"
+name = "wasite"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3922,9 +4003,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3932,9 +4013,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3945,9 +4026,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3987,6 +4068,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "which"
 version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,6 +4099,19 @@ dependencies = [
  "home",
  "rustix 0.38.44",
  "winsafe",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+dependencies = [
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT"
 
 [features]
 default = []
-jj = ["dep:jj-lib", "dep:pollster"]
+jj = ["dep:jj-lib", "dep:pollster", "dep:whoami"]
 
 [[bin]]
 name = "koji"
@@ -41,12 +41,14 @@ gix = "0.80.0"
 # Optional jj support
 jj-lib = { version = "0.39", optional = true }
 pollster = { version = "0.4", optional = true }
+whoami = { version = "2.1.2", optional = true }
 
 [dev-dependencies]
 assert_cmd = "2.0.16"
 predicates = "3.1.2"
 tempfile = "3.12.0"
 git2 = "0.20.3"
+serial_test = "3.5.0"
 
 [target.'cfg(not(windows))'.dev-dependencies]
 rexpect = "0.6.2"

--- a/src/lib/vcs.rs
+++ b/src/lib/vcs.rs
@@ -258,6 +258,159 @@ impl VcsBackend {
     }
 
     // ---- jj-specific implementations ----
+    //
+    // The config-loading helpers below are ported and modified from the jj CLI
+    // (cli/src/config.rs) to reproduce the same layer ordering:
+    //   Default → EnvBase → User → Repo → EnvOverrides
+    // These functions are derived from jj and retain their original copyright:
+    // Copyright 2022 The Jujutsu Authors
+    //
+    // Licensed under the Apache License, Version 2.0 (the "License");
+    // you may not use these files except in compliance with the License.
+    // You may obtain a copy of the License at
+    //
+    //     https://www.apache.org/licenses/LICENSE-2.0
+    //
+    // Unless required by applicable law or agreed to in writing, software
+    // distributed under the License is distributed on an "AS IS" BASIS,
+    // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    // See the License for the specific language governing permissions and
+    // limitations under the License.
+
+    /// Environment variables that should be overridden by config values.
+    ///
+    /// Ported from jj cli/src/config.rs `env_base_layer()`.
+    /// Modifications: Removed NO_COLOR, VISUAL, EDITOR handling (not needed for koji's use case).
+    #[cfg(feature = "jj")]
+    fn jj_env_base_layer() -> jj_lib::config::ConfigLayer {
+        use jj_lib::config::{ConfigLayer, ConfigSource};
+
+        let mut layer = ConfigLayer::empty(ConfigSource::EnvBase);
+        if let Ok(value) = whoami::hostname() {
+            layer.set_value("operation.hostname", value).unwrap();
+        }
+        if let Ok(value) = whoami::username() {
+            layer.set_value("operation.username", value).unwrap();
+        } else if let Ok(value) = std::env::var("USER") {
+            // On Unix, $USER is set by login(1). Use it as a fallback because
+            // getpwuid() of musl libc appears not (fully?) supporting nsswitch.
+            layer.set_value("operation.username", value).unwrap();
+        }
+        layer
+    }
+
+    /// Environment variables that override config values.
+    ///
+    /// Ported from jj cli/src/config.rs `env_overrides_layer()`.
+    /// Modifications: Removed JJ_EDITOR and JJ_PAGER handling (not needed for koji's use case).
+    #[cfg(feature = "jj")]
+    fn jj_env_overrides_layer() -> jj_lib::config::ConfigLayer {
+        use jj_lib::config::{ConfigLayer, ConfigSource};
+
+        let mut layer = ConfigLayer::empty(ConfigSource::EnvOverrides);
+        if let Ok(value) = std::env::var("JJ_USER") {
+            layer.set_value("user.name", value).unwrap();
+        }
+        if let Ok(value) = std::env::var("JJ_EMAIL") {
+            layer.set_value("user.email", value).unwrap();
+        }
+        if let Ok(value) = std::env::var("JJ_TIMESTAMP") {
+            layer.set_value("debug.commit-timestamp", value).unwrap();
+        }
+        if let Ok(Ok(value)) = std::env::var("JJ_RANDOMNESS_SEED").map(|s| s.parse::<i64>()) {
+            layer.set_value("debug.randomness-seed", value).unwrap();
+        }
+        if let Ok(value) = std::env::var("JJ_OP_TIMESTAMP") {
+            layer.set_value("debug.operation-timestamp", value).unwrap();
+        }
+        if let Ok(value) = std::env::var("JJ_OP_HOSTNAME") {
+            layer.set_value("operation.hostname", value).unwrap();
+        }
+        if let Ok(value) = std::env::var("JJ_OP_USERNAME") {
+            layer.set_value("operation.username", value).unwrap();
+        }
+        layer
+    }
+
+    /// Resolves the list of user config paths following jj's precedence rules.
+    ///
+    /// Ported from jj cli/src/config.rs `UnresolvedConfigEnv::resolve()`.
+    /// Modifications: Uses `dirs` crate instead of `etcetera` for platform directories.
+    #[cfg(feature = "jj")]
+    fn jj_user_config_paths() -> Vec<PathBuf> {
+        use std::env::split_paths;
+
+        // $JJ_CONFIG takes full precedence when set
+        if let Ok(jj_config) = std::env::var("JJ_CONFIG") {
+            return split_paths(&jj_config)
+                .filter(|p| !p.as_os_str().is_empty())
+                .collect();
+        }
+
+        let home_dir = dirs::home_dir();
+        let config_dir = dirs::config_dir();
+
+        let mut paths = Vec::new();
+
+        let home_config_path = home_dir.map(|d| d.join(".jjconfig.toml"));
+        let platform_config_path = config_dir.clone().map(|d| d.join("jj").join("config.toml"));
+        let platform_config_dir = config_dir.map(|d| d.join("jj").join("conf.d"));
+
+        if let Some(ref path) = home_config_path {
+            if path.exists() || platform_config_path.is_none() {
+                paths.push(path.clone());
+            }
+        }
+
+        // This should be the default config created if there's
+        // no user config and `jj config edit` is executed.
+        if let Some(path) = platform_config_path {
+            paths.push(path);
+        }
+
+        if let Some(path) = platform_config_dir {
+            if path.exists() {
+                paths.push(path);
+            }
+        }
+
+        paths
+    }
+
+    /// Builds a jj StackedConfig matching the layer ordering used by the jj CLI.
+    ///
+    /// Ported from jj cli/src/config.rs `config_from_environment()` +
+    /// `ConfigEnv::reload_user_config()`.
+    /// Modifications: Simplified to only load user and repo config layers.
+    #[cfg(feature = "jj")]
+    fn jj_load_config(workspace_root: &Path) -> Result<jj_lib::config::StackedConfig> {
+        use jj_lib::config::{ConfigSource, StackedConfig};
+
+        let mut config = StackedConfig::with_defaults();
+
+        // EnvBase
+        config.add_layer(Self::jj_env_base_layer());
+
+        // User config files
+        for path in Self::jj_user_config_paths() {
+            if path.is_dir() {
+                let _ = config.load_dir(ConfigSource::User, &path);
+            } else if path.exists() {
+                let _ = config.load_file(ConfigSource::User, &path);
+            }
+        }
+
+        // Repo-level config
+        let repo_config = workspace_root.join(".jj").join("repo").join("config.toml");
+        if repo_config.is_file() {
+            let _ = config.load_file(ConfigSource::Repo, &repo_config);
+        }
+
+        // EnvOverrides
+        config.add_layer(Self::jj_env_overrides_layer());
+
+        Ok(config)
+    }
 
     #[cfg(feature = "jj")]
     fn jj_load_repo(
@@ -266,13 +419,12 @@ impl VcsBackend {
         std::sync::Arc<jj_lib::repo::ReadonlyRepo>,
         jj_lib::ref_name::WorkspaceNameBuf,
     )> {
-        use jj_lib::config::StackedConfig;
         use jj_lib::repo::StoreFactories;
         use jj_lib::settings::UserSettings;
         use jj_lib::workspace::{default_working_copy_factories, Workspace};
         use pollster::FutureExt as _;
 
-        let config = StackedConfig::with_defaults();
+        let config = Self::jj_load_config(workspace_root)?;
         let settings =
             UserSettings::from_config(config).context("could not create jj UserSettings")?;
         let store_factories = StoreFactories::default();
@@ -381,5 +533,246 @@ impl VcsBackend {
         }
 
         Ok(scopes)
+    }
+}
+
+#[cfg(feature = "jj")]
+#[cfg(test)]
+mod tests {
+    use serial_test::serial;
+
+    use super::*;
+    use std::env;
+
+    use std::collections::HashMap;
+    use std::ffi::{OsStr, OsString};
+
+    struct EnvRestoreGuard(HashMap<OsString, Option<OsString>>);
+
+    impl Drop for EnvRestoreGuard {
+        fn drop(&mut self) {
+            for (key, value) in self.0.iter() {
+                match value {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
+    impl EnvRestoreGuard {
+        pub fn new() -> Self {
+            Self(HashMap::new())
+        }
+
+        pub fn set_var<K, V>(&mut self, key: K, value: V)
+        where
+            K: Into<OsString>,
+            V: AsRef<OsStr>,
+        {
+            let key = key.into();
+            let val = env::var_os(&key);
+            env::set_var(&key, value);
+            self.0.insert(key, val);
+        }
+
+        pub fn remove_var<K>(&mut self, key: K)
+        where
+            K: Into<OsString>,
+        {
+            let key = key.into();
+            let val = env::var_os(&key);
+            env::remove_var(&key);
+            self.0.insert(key, val);
+        }
+    }
+
+    /// Tests that jj_env_base_layer creates a valid layer
+    #[test]
+    #[serial]
+    fn test_jj_env_base_layer_creates_valid_layer() {
+        let layer = VcsBackend::jj_env_base_layer();
+        assert!(matches!(
+            layer.source,
+            jj_lib::config::ConfigSource::EnvBase
+        ));
+    }
+
+    /// Tests jj_env_overrides_layer with all JJ_* environment variables set
+    #[test]
+    #[serial]
+    fn test_jj_env_overrides_layer_with_all_vars() {
+        let mut guard = EnvRestoreGuard::new();
+
+        guard.set_var("JJ_USER", "Test User");
+        guard.set_var("JJ_EMAIL", "test@example.com");
+        guard.set_var("JJ_TIMESTAMP", "1234567890");
+        guard.set_var("JJ_RANDOMNESS_SEED", "42");
+        guard.set_var("JJ_OP_TIMESTAMP", "0987654321");
+        guard.set_var("JJ_OP_HOSTNAME", "test-host");
+        guard.set_var("JJ_OP_USERNAME", "test-username");
+
+        let layer = VcsBackend::jj_env_overrides_layer();
+
+        assert!(matches!(
+            layer.source,
+            jj_lib::config::ConfigSource::EnvOverrides
+        ));
+    }
+
+    /// Tests jj_env_overrides_layer without any JJ_* environment variables
+    #[test]
+    #[serial]
+    fn test_jj_env_overrides_layer_empty() {
+        let mut guard = EnvRestoreGuard::new();
+
+        for var in [
+            "JJ_USER",
+            "JJ_EMAIL",
+            "JJ_TIMESTAMP",
+            "JJ_RANDOMNESS_SEED",
+            "JJ_OP_TIMESTAMP",
+            "JJ_OP_HOSTNAME",
+            "JJ_OP_USERNAME",
+        ] {
+            guard.remove_var(var);
+        }
+
+        let layer = VcsBackend::jj_env_overrides_layer();
+
+        assert!(matches!(
+            layer.source,
+            jj_lib::config::ConfigSource::EnvOverrides
+        ));
+    }
+
+    /// Tests jj_user_config_paths with JJ_CONFIG environment variable (single path)
+    #[test]
+    #[serial]
+    fn test_jj_user_config_paths_jj_config_single() {
+        let mut guard = EnvRestoreGuard::new();
+
+        guard.set_var("JJ_CONFIG", "/tmp/test/jjconfig.toml");
+
+        let paths = VcsBackend::jj_user_config_paths();
+
+        assert_eq!(paths.len(), 1);
+        assert_eq!(paths[0], PathBuf::from("/tmp/test/jjconfig.toml"));
+    }
+
+    /// Tests jj_user_config_paths with multiple paths in JJ_CONFIG
+    #[test]
+    #[serial]
+    fn test_jj_user_config_paths_jj_config_multiple() {
+        let mut guard = EnvRestoreGuard::new();
+
+        // Use (semi)colon-separated paths which split_paths handles
+        guard.set_var(
+            "JJ_CONFIG",
+            cfg_select! {
+                unix => "/tmp/test1:/tmp/test2",
+                _ => "/tmp/test1;/tmp/test2"
+            },
+        );
+
+        let paths = VcsBackend::jj_user_config_paths();
+
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&PathBuf::from("/tmp/test1")));
+        assert!(paths.contains(&PathBuf::from("/tmp/test2")));
+    }
+
+    /// Tests that jj_user_config_paths filters out empty paths from JJ_CONFIG
+    #[test]
+    #[serial]
+    fn test_jj_user_config_paths_filters_empty() {
+        let mut guard = EnvRestoreGuard::new();
+
+        // Use (semi)colon-separated paths with empty entries
+        guard.set_var(
+            "JJ_CONFIG",
+            cfg_select! {
+                unix => "/tmp/test1:::/tmp/test2",
+                _ => "/tmp/test1;;;/tmp/test2"
+            },
+        );
+
+        let paths = VcsBackend::jj_user_config_paths();
+
+        assert_eq!(paths.len(), 2);
+        assert!(paths.contains(&PathBuf::from("/tmp/test1")));
+        assert!(paths.contains(&PathBuf::from("/tmp/test2")));
+    }
+
+    /// Tests jj_user_config_paths without JJ_CONFIG set (uses default paths)
+    #[test]
+    #[serial]
+    #[cfg(target_os = "linux")]
+    fn test_jj_user_config_paths_default() {
+        let mut guard = EnvRestoreGuard::new();
+        guard.remove_var("JJ_CONFIG");
+
+        // Set HOME to a temporary directory for reproducibility
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let home_path = temp_dir.path();
+        guard.set_var("HOME", home_path);
+
+        let xdg_config = home_path.join(".config");
+        std::fs::create_dir_all(&xdg_config).expect("Failed to create XDG_CONFIG_HOME");
+        guard.set_var("XDG_CONFIG_HOME", &xdg_config);
+
+        let jj_config_dir = xdg_config.join("jj");
+        std::fs::create_dir_all(&jj_config_dir).expect("Failed to create jj config dir");
+
+        let paths = VcsBackend::jj_user_config_paths();
+
+        let expected_platform_config = jj_config_dir.join("config.toml");
+        assert!(!paths.is_empty());
+        assert!(
+            paths.contains(&expected_platform_config),
+            "Should contain platform config path: {}",
+            expected_platform_config.display()
+        );
+    }
+
+    /// Tests jj_load_config creates a valid StackedConfig with basic structure
+    #[test]
+    #[serial]
+    fn test_jj_load_config_creates_valid_config() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let workspace_root = temp_dir.path();
+
+        let jj_dir = workspace_root.join(".jj").join("repo");
+        std::fs::create_dir_all(&jj_dir).expect("Failed to create .jj/repo dir");
+
+        let config = VcsBackend::jj_load_config(workspace_root).expect("Failed to load config");
+
+        assert!(!config.layers().is_empty());
+    }
+
+    /// Tests jj_load_config loads repo config file when present
+    #[test]
+    #[serial]
+    fn test_jj_load_config_with_repo_config() {
+        let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
+        let workspace_root = temp_dir.path();
+
+        let jj_dir = workspace_root.join(".jj").join("repo");
+        std::fs::create_dir_all(&jj_dir).expect("Failed to create .jj/repo dir");
+
+        let repo_config_path = jj_dir.join("config.toml");
+        std::fs::write(
+            &repo_config_path,
+            r#"
+[user]
+name = "Test Repo User"
+email = "repo-test@example.com"
+"#,
+        )
+        .expect("Failed to write repo config");
+
+        let config = VcsBackend::jj_load_config(workspace_root).expect("Failed to load config");
+
+        assert!(!config.layers().is_empty());
     }
 }


### PR DESCRIPTION
Previously, jj_load_repo used StackedConfig::with_defaults() which only contains empty strings for user.name and user.email. When rewrite_commit is called, jj-lib sets the committer field from settings.signature(), resulting in an empty committer that prevents pushing to git remotes.

Port the config-loading helpers from the jj CLI (env_base_layer, env_overrides_layer, UnresolvedConfigEnv::resolve) and wire them together so that the StackedConfig is built with the same layer ordering as the jj CLI: Default, EnvBase, User, Repo, EnvOverrides.